### PR TITLE
DO NOT MERGE: Tidy up branch

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,8 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.4.0"]
+  :dependencies [[org.clojure/clojure "1.5.0-beta1"]
+                 [org.cloudhoist/codeq "0.1.0-SNAPSHOT"]
                  [clj-redis "0.0.12"]
                  [fs/fs "1.3.2"]]
   :main jida-worker.core)

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,10 @@
 (defproject jida-worker "0.1.0-SNAPSHOT"
+  :plugins [[lein-swank "1.4.0"]]
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [clj-redis "0.0.12"]]
+                 [clj-redis "0.0.12"]
+                 [fs/fs "1.3.2"]]
   :main jida-worker.core)

--- a/src/jida_worker/core.clj
+++ b/src/jida_worker/core.clj
@@ -1,39 +1,62 @@
 (ns jida-worker.core
   (:use [clojure.java.shell :only [sh with-sh-dir]])
-  (:require [clj-redis.client :as redis])
+  (:require [clj-redis.client :as redis]
+            [fs.core :as fs]
+            [datomic.codeq.core :as codeq])
   (:gen-class))
 
-(def default-redis-uri "redis://redistogo:dfcab96405c0df37b9e0088d69995010@gar.redistogo.com:9184/")
-(def default-codeq-jar-path"/Users/wei/projects/clojure/codeq/target/codeq-0.1.0-SNAPSHOT-standalone.jar")
-(def default-datomic-uri "datomic:free://localhost:4334/git")
+(defn log [& messages]
+  (apply println messages))
+
+(def redis-uri
+  (or (System/getenv "REDIS_URI")
+      (System/getenv "REDISTOGO_URL")
+      "redis://localhost:6379/"))
+
+(def codeq-jar-path
+  (or (System/getenv "CODEQ_JAR_PATH")
+      "/Users/wei/projects/clojure/codeq/target/codeq-0.1.0-SNAPSHOT-standalone.jar"))
+
+(def datomic-uri
+  (or (System/getenv "DATOMIC_URI")
+      "datomic:free://localhost:4334/git"))
+
 (def redis-conn (atom nil))
 
 (defn db []
   (or @redis-conn
-      (let [uri (or (System/getenv "REDISTOGO_URL") default-redis-uri)]
-        (reset! redis-conn (redis/init :url uri)))))
+      (reset! redis-conn (redis/init :url redis-uri))))
 
-(def working-dir "/tmp")
-(defn process-repo [address]
-  (let [[[_ dirname]] (re-seq #".*/(.*).git" address)]
-    (with-sh-dir
-      working-dir
-      (println "Cloning " address "..")
-      (sh "git" "clone" address))
-    (with-sh-dir
-      (str working-dir "/" dirname)
-      (println "Importing into codeq..")
-      (println (sh "java"
-          "-server" "-Xmx1g"
-          "-jar" (or (System/getenv "CODEQ_JAR_PATH") default-codeq-jar-path)
-          (or (System/getenv "DATOMIC_URI") default-datomic-uri)))
-      (println "Done."))))
+(defn git-clone [repo-address destination]
+  (log "Git cloning into " destination)
+  (let [[[_ dirname]] (re-seq #".*/(.*).git" repo-address)]
+    (sh "git" "clone" repo-address)
+    (str (clojure.string/trim (:out (sh "pwd"))) "/" dirname)))
+
+(defn codeq-import [source-path codeq-jar-path datomic-uri]
+  (log "Running Codeq on " (clojure.string/trim source-path) "...")
+  (sh "cd" (clojure.string/trim source-path))
+  (let [cmd ["java"
+           "-server" "-Xmx1g"
+           "-jar" codeq-jar-path
+           datomic-uri]]
+    (log (apply sh cmd))))
+
+(defn process-repo [repo-address]
+  (with-sh-dir (fs/temp-dir "jida-worker-")
+    (let [cloned-dir (git-clone repo-address ".")
+          cd (sh "cd" cloned-dir)
+          conn '(codeq/ensure-db datomic-uri)
+          [repo-uri repo-name] '(codeq/get-repo-uri)]
+      (codeq/main datomic-uri))))
 
 (defn get-tasks []
-  (println "Waiting for a task..")
+  (log "Waiting for a task..")
   (let [[_ address] (redis/blpop (db) ["tasks"] 0)]
-    (process-repo address)))
+    (log "Processing repo at " address)
+    (let [result (process-repo address)]
+      (log "Finished processing repo with result: " result))))
 
 (defn -main [& m]
-  (println (System/getenv))
+  (log (System/getenv))
   (dorun (repeatedly get-tasks)))


### PR DESCRIPTION
Thought I was doing a minor refactor, but lead down an all-day rabbit hole.

Cleaned up some definitions, split out the methods to be smaller, tidied up a bit. Would love to hear your thoughts on the naming/legibility of the code, small as it is.

Biggest part is that I brought in codeq as a jar so we can use it programmatically without shelling out. The code looks lovely with it, but it turns out that https://github.com/Datomic/codeq/blob/master/src/datomic/codeq/core.clj#L256 doesn't allow us to pass in the correct ENV, so codeq just runs on the existing directory and re-imports jida-worker.

I like the new code a lot, but wonder if:
1. We'd have to fork codeq, make the tiny change in a few functions so the env is providable, and it's more modular in general.
2. We can make a helper function that does all that itself inside of jida-workers

Not that we have to go this route, just curious about the problem.
